### PR TITLE
Add scopeBannedByType in Bannable.php to allow scoping banned models by type

### DIFF
--- a/src/Traits/Bannable.php
+++ b/src/Traits/Bannable.php
@@ -69,4 +69,18 @@ trait Bannable
             $query->where('metas->'.$key, $value)->notExpired();
         });
     }
+
+    /**
+     *
+     * @param  Builder $query
+     * @param  string  $className
+     * @return void
+     */
+    public function scopeBannedByType(Builder $query, string $className) : void
+    {
+        $query->whereHas('bans', function ($query) use ($className) {
+            $query->where('created_by_type', $className)->notExpired();
+        });
+    }
+
 }


### PR DESCRIPTION
Thank you for this package, I have been using it for quite some time in my projects. Very handy :).

I have added a new scope in Bannable.php that allows to scope by type.

So we can do the following:

`$model->bannedByType(\App\Models\Supervisor::class)->get()` which will return the Collection scoped by the type passed.

I have also ran the tests just to make sure I did not break any previously made code.

Thank you.