### PR TITLE
Add RedirectResponse type for render() on BanhammerException.

### DIFF
--- a/src/Exceptions/BanhammerException.php
+++ b/src/Exceptions/BanhammerException.php
@@ -3,6 +3,7 @@
 namespace Mchev\Banhammer\Exceptions;
 
 use Exception;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
@@ -26,7 +27,7 @@ class BanhammerException extends HttpException
     /**
      * Render the exception into an HTTP response.
      */
-    public function render(Request $request): Response
+    public function render(Request $request): Response|RedirectResponse
     {
         return (config('ban.fallback_url'))
             ? redirect(config('ban.fallback_url'))


### PR DESCRIPTION
When using the ban.fallback_url config option the response is a RedirectResponse but the method return type only accepts Response.