### PR TITLE
Improve banned() scope to be used for both banned and unbanned queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,10 @@ $bannedTeams = Team::banned()->get();
 $notBannedTeams = Team::notBanned()->get();
 ```
 
+> Alternatively to `notBanned()` you may also use the `banned()` scope to filter not-banned models: `Team::banned(false)`. Like this, you could simply use the `banned` scope for e.g. [spatie/laravel-query-builder](https://spatie.be/docs/laravel-query-builder/v5/features/filtering#content-scope-filters) [Scope Filters](https://spatie.be/docs/laravel-query-builder/v5/features/filtering#content-scope-filters), instead of using more complex ways to apply either `banned` or `notBanned` scopes.
+
 Unban
+
 ```php
 $user->unban();
 ```

--- a/src/Traits/Bannable.php
+++ b/src/Traits/Bannable.php
@@ -63,11 +63,11 @@ trait Bannable
     /**
      * Scope a query to include only models that are currently banned.
      */
-    public function scopeBanned(Builder $query): void
+    public function scopeBanned(Builder $query, bool $banned = true): void
     {
-        $query->whereHas('bans', function ($query) {
-            $query->notExpired();
-        });
+        $banned
+            ? $query->whereHas('bans', fn ($query) => $query->notExpired())
+            : $this->scopeNotBanned($query);
     }
 
     /**


### PR DESCRIPTION
Allow `banned()` scope to be used for both banned and unbanned queries, so it can be used for scope filters.

Like this, we could simply use the `banned` scope for [`spatie/laravel-query-builder` Scope Filters](https://spatie.be/docs/laravel-query-builder/v5/features/filtering#content-scope-filters), instead of using more complex ways to apply either `banned` or `notBanned` scopes.