### PR TITLE
Add Support To Enable and customize `unban` command 

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -92,4 +92,8 @@ return [
     */
     'cache_duration' => 120, // Duration in minutes
 
+
+    'auto_schedule' => true,
+    'schedule_frequency' => 'everyMinute',
+
 ];

--- a/src/BanhammerServiceProvider.php
+++ b/src/BanhammerServiceProvider.php
@@ -50,8 +50,11 @@ class BanhammerServiceProvider extends ServiceProvider
         }
 
         $this->app->booted(function () {
-            $schedule = $this->app->make(Schedule::class);
-            $schedule->command('banhammer:unban')->everyMinute();
+            if (config('ban.auto_schedule', true)) {
+                $schedule = $this->app->make(Schedule::class);
+                $frequency = config('ban.schedule_frequency', 'everyMinute');
+                $schedule->command('banhammer:unban')->$frequency();
+            }
         });
 
     }


### PR DESCRIPTION
This pull request introduces configurable scheduling for the `banhammer:unban` command, making the scheduling behavior more flexible and easier to manage through configuration. The main changes allow enabling/disabling auto-scheduling and customizing the scheduling frequency.

Configuration enhancements:

* Added `auto_schedule` and `schedule_frequency` options to the `ban` configuration in `config/config.php`, allowing users to control whether the unban command is auto-scheduled and to set the desired frequency.

Scheduling logic improvements:

* Updated the `boot` method in `BanhammerServiceProvider` to check the `auto_schedule` flag and use the `schedule_frequency` value when scheduling the `banhammer:unban` command, making the scheduling behavior dynamic based on configuration.